### PR TITLE
log user callback errors by default; allow custom error handling

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /**
  * Factory method that creates a new callback registry instance
  */
-declare function Factory(): CallbackRegistry;
+declare function Factory(options?: InitOptions): CallbackRegistry;
 export default Factory;
 
 export interface CallbackRegistry {
@@ -31,4 +31,10 @@ export interface Callback {
 
 export interface UnsubscribeFunction {
     (): void;
+}
+
+export type ErrorHandler = (err: Error) => void
+
+export interface InitOptions {
+    errorHandling: "log" | "silent" | "throw" | ErrorHandler;
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,7 +1,7 @@
 /**
  * Factory method that creates a new callback registry instance
  */
-declare function Factory(): CallbackRegistry;
+declare function Factory(options?: InitOptions): CallbackRegistry;
 export default Factory;
 
 export interface CallbackRegistry {
@@ -31,4 +31,10 @@ export interface Callback {
 
 export interface UnsubscribeFunction {
     (): void;
+}
+
+export type ErrorHandler = (err: Error) => void
+
+export interface InitOptions {
+    errorHandling: "log" | "silent" | "throw" | ErrorHandler;
 }


### PR DESCRIPTION
This PR changes the default behavior of the callback-registry when a user-supplied callback throws an exception. 
Before exceptions were silenced. 
Now exceptions will be logged to the console as errors.

Additionally the user can set the error handling behavior when creating the registry instance. Exceptions can be logged (the default), silenced, re-thrown, or handled by a custom error-handling function.

If the custom error-handling function throws an exception, that exception will not be handled or caught by the registry instance.