### PR TITLE
feat: Extend `add()` with an optional replayArgumentsArr argument ✨

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,9 +7,13 @@ export default Factory;
 export interface CallbackRegistry {
     /**
      * Adds a new callback to the registry under some key.
-     * The callback will be notified when someone executes
+     * The callback will be notified when someone executes.
+     * The callback will be called with all replayArguments:
+     * e.g. add('clientAdded', (name, age) => console.log(name, age), [['Alice', 25], ['Bob', 30]])
+     * will invoke the callback with 'Alice', 25 and 'Bob', 30 *after* returning the unsubscribe function.
+     * An example use case are events that need to call the provided callback with previous values (replay) and want to allow the callback to unsubscribe while replaying
      */
-    add(key: string, callback: Callback): UnsubscribeFunction;
+    add(key: string, callback: Callback, replayArgumentsArr?: any[] | Array<any[]>): UnsubscribeFunction;
 
     /**
      * Executes all callbacks registered for a certain key.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -7,9 +7,13 @@ export default Factory;
 export interface CallbackRegistry {
     /**
      * Adds a new callback to the registry under some key.
-     * The callback will be notified when someone executes
+     * The callback will be notified when someone executes.
+     * The callback will be called with all replayArguments:
+     * e.g. add('clientAdded', (name, age) => console.log(name, age), [['Alice', 25], ['Bob', 30]])
+     * will invoke the callback with 'Alice', 25 and 'Bob', 30 *after* returning the unsubscribe function.
+     * An example use case are events that need to call the provided callback with previous values (replay) and want to allow the callback to unsubscribe while replaying
      */
-    add(key: string, callback: Callback): UnsubscribeFunction;
+    add(key: string, callback: Callback, replayArgumentsArr?: any[] | Array<any[]>): UnsubscribeFunction;
 
     /**
      * Executes all callbacks registered for a certain key.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "callback-registry",
-  "version": "2.5.0",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -691,9 +691,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://repo.tick42.com:443/api/npm/tick42-npm/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha1-sYdSuzeSvBoCgTNff26/G7/FuR0=",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "devDependencies": {
         "chai": "4.2.0",
         "mocha": "6.2.2",
-        "typescript": "3.6.4"
+        "typescript": "^3.9.6"
     },
     "publishConfig": {
         "registry": "https://registry.npmjs.org"

--- a/tests/index.js
+++ b/tests/index.js
@@ -368,7 +368,25 @@ describe('callback-registry', function (done) {
         }
     });
 
-    it('should invoke the callback provided to add with the replayArguments', function (done) {
+    it('should invoke the callback provided to add with the replayArguments (single argument)', function (done) {
+        const replayArgumentsArr = ['Alice', 'Bob'];
+
+        const invokedWith = [];
+
+        const registry = Registry();
+
+        const callback = (name) => {
+            invokedWith.push(name);
+
+            if (invokedWith.length === replayArgumentsArr.length && invokedWith.every((arg) => replayArgumentsArr.includes(arg))) {
+                done();
+            }
+        };
+
+        registry.add('test', callback, replayArgumentsArr);
+    });
+
+    it('should invoke the callback provided to add with the replayArguments (multiple arguments)', function (done) {
         const replayArgumentsArr = [['Alice', 25], ['Bob', 30]];
 
         const invokedWith = [];

--- a/tests/index.js
+++ b/tests/index.js
@@ -71,13 +71,13 @@ describe('callback-registry', function (done) {
         registry.execute('test', 1, '2', 3);
     });
 
-    it('should return arguments', function(){
+    it('should return arguments', function () {
         var registry = Registry();
         registry.add('test', function () {
-            return {a:1};
+            return { a: 1 };
         });
         registry.add('test', function () {
-            return {a:2};
+            return { a: 2 };
         });
 
         var result = registry.execute('test');
@@ -87,14 +87,14 @@ describe('callback-registry', function (done) {
         expect(result[1].a).to.equal(2);
     });
 
-    it('should return results from the callbacks in array', function(){
+    it('should return results from the callbacks in array', function () {
         var registry = Registry();
         registry.add('test', function () {
-            return {a:1};
+            return { a: 1 };
         });
         var unsubscribe2 = registry.add('test', function () {
             unsubscribe2();
-            return {a:2};
+            return { a: 2 };
         });
 
         var result = registry.execute('test');
@@ -103,17 +103,17 @@ describe('callback-registry', function (done) {
         expect(result.length).to.equal(1);
     });
 
-    it('should return empty array if no subscribers', function(){
+    it('should return empty array if no subscribers', function () {
         var registry = Registry();
         var result = registry.execute('test');
         expect(Array.isArray(result)).to.equal(true);
         expect(result.length).to.equal(0);
     });
 
-    it('should return results from the callbacks even if some of the callbacks throw Error', function(){
+    it('should return results from the callbacks even if some of the callbacks throw Error', function () {
         var registry = Registry();
         registry.add('test', function () {
-           throw Error('test');
+            throw Error('test');
         });
 
         registry.add('test', function () {
@@ -127,7 +127,7 @@ describe('callback-registry', function (done) {
         expect(result[1]).to.equal(1);
     });
 
-    it('bugfix (https://github.com/gdavidkov) - issue when unsubscribing with more than one callbacks per key', function() {
+    it('bugfix (https://github.com/gdavidkov) - issue when unsubscribing with more than one callbacks per key', function () {
         var registry = Registry();
 
         var executions1 = 0;
@@ -151,10 +151,10 @@ describe('callback-registry', function (done) {
         expect(executions2).to.equal(1);
     });
 
-    it('should remove all callbacks on clear', function(){
+    it('should remove all callbacks on clear', function () {
         var registry = Registry();
         registry.add('test', function () {
-           throw Error('test');
+            throw Error('test');
         });
 
         registry.add('test', function () {
@@ -166,10 +166,10 @@ describe('callback-registry', function (done) {
     });
 
 
-    it('after clear I can call remove and it should not fail', function(){
+    it('after clear I can call remove and it should not fail', function () {
         var registry = Registry();
         var remove1 = registry.add('test', function () {
-           throw Error('test');
+            throw Error('test');
         });
 
         var remove2 = registry.add('test', function () {
@@ -182,11 +182,11 @@ describe('callback-registry', function (done) {
         remove2();
     });
 
-    it('should remove all callbacks for key on clearKey', function(done){
+    it('should remove all callbacks for key on clearKey', function (done) {
         var flag = null;
         var registry = Registry();
         registry.add('test', function () {
-           done('should not have called this')
+            done('should not have called this')
         });
 
         registry.add('testOtherKey', function () {
@@ -200,10 +200,10 @@ describe('callback-registry', function (done) {
         done();
     });
 
-    it('should not fail if execute key after clearKey', function(done){
+    it('should not fail if execute key after clearKey', function (done) {
         var registry = Registry();
         registry.add('test', function () {
-           done('should not have called this')
+            done('should not have called this')
         });
 
         registry.clearKey('test');
@@ -211,11 +211,11 @@ describe('callback-registry', function (done) {
         done();
     });
 
-    it('should execute one callback after clearKey and adding a new callback', function(done){
+    it('should execute one callback after clearKey and adding a new callback', function (done) {
         var flag = null;
         var registry = Registry();
         registry.add('test', function () {
-           done('should not have called this')
+            done('should not have called this')
         });
 
         registry.clearKey('test');
@@ -229,16 +229,16 @@ describe('callback-registry', function (done) {
         done();
     });
 
-    it('should clearKey for key that was never added', function(done){
+    it('should clearKey for key that was never added', function (done) {
         var registry = Registry();
         registry.clearKey('test');
         done();
     });
 
-    it('should log errors in console with default options', function(done){
+    it('should log errors in console with default options', function (done) {
         var registry = Registry();
         var remove1 = registry.add('test', function () {
-           throw Error('test-error');
+            throw Error('test-error');
         });
 
         var oldConError = console.error;
@@ -252,10 +252,10 @@ describe('callback-registry', function (done) {
         remove1();
     });
 
-    it('should log errors in console with log option set', function(done){
-        var registry = Registry({errorHandling: "log"});
+    it('should log errors in console with log option set', function (done) {
+        var registry = Registry({ errorHandling: "log" });
         var remove1 = registry.add('test', function () {
-           throw Error('test-error');
+            throw Error('test-error');
         });
 
         var oldConError = console.error;
@@ -269,10 +269,10 @@ describe('callback-registry', function (done) {
         remove1();
     });
 
-    it('should silence errors with silent set', function(done){
-        var registry = Registry({errorHandling: "silent"});
+    it('should silence errors with silent set', function (done) {
+        var registry = Registry({ errorHandling: "silent" });
         var remove1 = registry.add('test', function () {
-           throw Error('test-error');
+            throw Error('test-error');
         });
 
         var oldConError = console.error;
@@ -287,8 +287,8 @@ describe('callback-registry', function (done) {
         done();
     });
 
-    it('should explode with throw set', function(done){
-        var registry = Registry({errorHandling: "throw"});
+    it('should explode with throw set', function (done) {
+        var registry = Registry({ errorHandling: "throw" });
 
         var remove1 = registry.add('test', function () {
             throw Error('test-error');
@@ -311,9 +311,9 @@ describe('callback-registry', function (done) {
         }
     });
 
-    it('should use custom handler when it is set', function(done){
+    it('should use custom handler when it is set', function (done) {
         var witness = "";
-        var registry = Registry({errorHandling: function handleErr(){witness = "handled"}});
+        var registry = Registry({ errorHandling: function handleErr() { witness = "handled" } });
 
         var remove1 = registry.add('test', function () {
             throw Error('test-error');
@@ -337,9 +337,9 @@ describe('callback-registry', function (done) {
         }
     });
 
-    it('should explode when custom handler is set and explodes', function(done){
+    it('should explode when custom handler is set and explodes', function (done) {
         var registry = Registry({
-            errorHandling: function handleErr(err){
+            errorHandling: function handleErr(err) {
                 expect(err instanceof Error).to.be.true;
                 throw new Error(`handler-error : ${err}`);
             }
@@ -366,5 +366,47 @@ describe('callback-registry', function (done) {
             remove1();
             done();
         }
+    });
+
+    it('should invoke the callback provided to add with the replayArguments', function (done) {
+        const replayArgumentsArr = [['Alice', 25], ['Bob', 30]];
+
+        const invokedWith = [];
+
+        const registry = Registry();
+
+        const callback = (name, age) => {
+            invokedWith.push([name, age]);
+
+            if (invokedWith.length === replayArgumentsArr.length && invokedWith.every((args) => replayArgumentsArr.some((replayArgs) => replayArgs.every((arg, index) => arg === args[index])))) {
+                done();
+            }
+        };
+
+        registry.add('test', callback, replayArgumentsArr);
+    });
+
+    it('should not invoke the callback provided to add with the replayArguments after unsubscribing', function (done) {
+        const replayArgumentsArr = [['Alice', 25], ['Bob', 30]];
+
+        const invokedWith = [];
+
+        const registry = Registry();
+
+        let unsub;
+
+        setTimeout(() => {
+            if (invokedWith.length === 1 && replayArgumentsArr[0].every((arg, index) => arg === invokedWith[0][index])) {
+                done();
+            }
+        }, 1500);
+
+        const callback = (name, age) => {
+            invokedWith.push([name, age]);
+
+            unsub();
+        };
+
+        unsub = registry.add('test', callback, replayArgumentsArr);
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,16 @@
 {
-    "compilerOptions":
-    {
+    "compilerOptions": {
         "noImplicitAny": true,
         "sourceMap": true,
         "module": "commonjs",
         "target": "es5",
         "pretty": true,
-        "removeComments": true
+        "removeComments": true,
+        "lib": [
+            "es6",
+            "dom",
+            "es2017"
+        ]
     },
     "files": [
         "lib/index.ts"


### PR DESCRIPTION
Would allow the users to replay objects without the need to keep track of callbacks and isUnsubscribed flags inside of their implementation.

Would allow the following, which currently fails with `ReferenceError: "unsubscribeFunc" is not defined` on line 4 during replay:
``` js
const unsubscribeFunc = glue.appManager.onAppAdded((app) => {
  if (app.name === 'ClientList') {
    app.start();
    unsubscribeFunc();
  }
});
```

The transition would be seamless:

``` ts
public onAppAdded = (callback: (item: Glue42.AppManager.Application) => any): UnsubscribeFunction => {
  // 🐛 Since `onAppAdded` hasn't returned the callback can't call unsubsribeFunc as it isn't yet defined.
  this._replay(this._apps, callback);
  return this._registry.add("appAdded", callback);
}
```

Would turn into (also fixing the bug):

``` ts
public onAppAdded = (callback: (item: Glue42.AppManager.Application) => any): UnsubscribeFunction => {
  return this._registry.add("appAdded", callback, this._apps);
}
```

The alternative to this is, as mentioned in the beginning, to have the implementation track the callbacks and isUnsubscribed flags, which IMO is `callback-registry`'s responsibility.

Limitations:
⛔️ The user has no way to receive callback results (this is currently also the case).
⛔️ The user's callback can not accept an array as an **only** argument.
  - A solution to the latter would be to change `replayArgumentsArr`'s type from `any[] | Array<any[]>` to `Array<any[]>`. In this case the fix to our APIs would be:

``` ts
public onAppAdded = (callback: (item: Glue42.AppManager.Application) => any): UnsubscribeFunction => {
  return this._registry.add("appAdded", callback, this._apps.map((app) => [app]));
}
```